### PR TITLE
Update documentation 

### DIFF
--- a/Documentation/ContainerHierarchy.md
+++ b/Documentation/ContainerHierarchy.md
@@ -22,6 +22,6 @@ let cat = parentContainer.resolve(Animal.self)
 print(cat == nil) // prints "true"
 ```
 
-_[Next page: Properties](Assembler.md)_
+_[Next page: Modularizing Service Registration (Assembly)](Assembler.md)_
 
 _[Table of Contents](README.md)_


### PR DESCRIPTION
In Container Hierarchy documentation, the next page is called **Properties** and leading to **Modularizing Service Registration**.

Don't you guys think that it should be more understandable to be called `Modularizing Service Registration (Assembly)`, like we have in Table of Contents?

If so, this Pull Request does this small improvement in the documentation.